### PR TITLE
Fix CSS

### DIFF
--- a/css/popup.css
+++ b/css/popup.css
@@ -222,7 +222,7 @@ body {
 
 .errors-section {
     border-top: none;
-    padding-top: 0;
+    /* padding-top: 0; */
     margin-top: 0;
 }
 
@@ -908,7 +908,7 @@ body[data-show-resolved='false'] .error-item.resolved {
     background: var(--color-gray-100);
     border-radius: var(--border-radius-md);
     align-items: center;
-    border-bottom: 1px solid var(--color-gray-200);
+    /* border-bottom: 1px solid var(--color-gray-200); */
 }
 
 .filters-container .form-group {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CSS-only tweaks that adjust layout/visual styling; low risk aside from minor UI regressions in the popup.
> 
> **Overview**
> Removes two popup UI styling rules by commenting them out: `.errors-section` no longer forces `padding-top: 0`, and `.filters-container` no longer draws a bottom border.
> 
> This subtly changes spacing and separation in the errors panel and filter area to better match the updated layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29a2a3d97fa940fe131135110527ff3f63219542. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->